### PR TITLE
Improve importer

### DIFF
--- a/src/Famix-CPreproc-Entities/FamixCPreprocEntity.class.st
+++ b/src/Famix-CPreproc-Entities/FamixCPreprocEntity.class.st
@@ -20,6 +20,10 @@ FamixCPreprocEntity class >> metamodel [
 	^ FamixCPreprocModel metamodel
 ]
 
+{ #category : #'as yet unclassified' }
+FamixCPreprocEntity >> clearReplicationCache [
+]
+
 { #category : #testing }
 FamixCPreprocEntity >> isAssociation [
 

--- a/src/Famix-CPreproc-Importer/FamixCPreprocImporter.class.st
+++ b/src/Famix-CPreproc-Importer/FamixCPreprocImporter.class.st
@@ -46,6 +46,15 @@ FamixCPreprocImporter >> runOn: anXMLFilename [
 	model install
 ]
 
+{ #category : #'as yet unclassified' }
+FamixCPreprocImporter >> runOn: anXMLFilename modelName: name [
+	(anXMLFilename asFileReference readStreamDo: [ :stream | 
+		 XMLDOMParser parse: stream ]) acceptNodeVisitor: visitor.
+	model name: name.
+	model installWithCache: false.
+	model install.
+]
+
 { #category : #'accessing - testing' }
 FamixCPreprocImporter >> visitor [
 	^visitor 

--- a/src/Famix-CPreproc-Importer/FamixCPreprocImporter.class.st
+++ b/src/Famix-CPreproc-Importer/FamixCPreprocImporter.class.st
@@ -39,19 +39,13 @@ FamixCPreprocImporter >> rootFolder: anObject [
 ]
 
 { #category : #running }
-FamixCPreprocImporter >> runOn: anXMLFilename [
-
-	(anXMLFilename asFileReference readStreamDo: [ :stream | 
+FamixCPreprocImporter >> runOn: anXMLFilepath [
+	|filename modelName|
+	(anXMLFilepath asFileReference readStreamDo: [ :stream | 
 		 XMLDOMParser parse: stream ]) acceptNodeVisitor: visitor.
-	model install
-]
-
-{ #category : #'as yet unclassified' }
-FamixCPreprocImporter >> runOn: anXMLFilename modelName: name [
-	(anXMLFilename asFileReference readStreamDo: [ :stream | 
-		 XMLDOMParser parse: stream ]) acceptNodeVisitor: visitor.
-	model name: name.
-	model installWithCache: false.
+   filename := (anXMLFilepath splitOn: '/') last.
+   modelName := filename copyReplaceAll: '.xml' with: ''.
+	model name: modelName.
 	model install.
 ]
 


### PR DESCRIPTION
- Now we can pass a modelName parameter to the XML importer so it generates the Moose model and gives it a name right away. Before, we had to set the name manually by doing "model name: someName".
- After generating the MooseModel, I call "MooseModel install" to install it. This method calls clearReplicationCache in the metamodel entities class, but if this class does not have this method, an error occurs. This was occurring for me in FamixCpreprocEntities. Creating an empty method is a workaround to solve the issue.