### PR TITLE
Add traits and methods necessary for Architectural Map

### DIFF
--- a/src/Famix-CPreproc-Entities/FamixCPreprocCFile.class.st
+++ b/src/Famix-CPreproc-Entities/FamixCPreprocCFile.class.st
@@ -4,7 +4,6 @@ Generator for C language meta model (does not include C++ entities which are in 
 Class {
 	#name : #FamixCPreprocCFile,
 	#superclass : #FamixCPreprocDiskEntity,
-	#traits : 'TEntityMetaLevelDependency',
 	#classTraits : 'TEntityMetaLevelDependency classTrait',
 	#instVars : [
 		'#inclusion => FMMany type: #FamixCPreprocInclude opposite: #included',

--- a/src/Famix-CPreproc-Entities/FamixCPreprocDiskEntity.class.st
+++ b/src/Famix-CPreproc-Entities/FamixCPreprocDiskEntity.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixCPreprocDiskEntity,
 	#superclass : #FamixCPreprocEntity,
-	#traits : 'FamixTNamedEntity',
-	#classTraits : 'FamixTNamedEntity classTrait',
+	#traits : 'FamixTNamedEntity + TEntityMetaLevelDependency',
+	#classTraits : 'FamixTNamedEntity classTrait + TEntityMetaLevelDependency classTrait',
 	#instVars : [
 		'#parentFolder => FMOne type: #FamixCPreprocFolder opposite: #children'
 	],

--- a/src/Famix-CPreproc-Entities/FamixCPreprocInclude.class.st
+++ b/src/Famix-CPreproc-Entities/FamixCPreprocInclude.class.st
@@ -54,11 +54,6 @@ FamixCPreprocInclude >> includedBy: anObject [
 	includedBy := anObject
 ]
 
-{ #category : #testing }
-FamixCPreprocInclude >> isInvocation [
-	^false
-]
-
 { #category : #accessing }
 FamixCPreprocInclude >> isLocal [
 

--- a/src/Famix-CPreproc-Entities/FamixCPreprocInclude.class.st
+++ b/src/Famix-CPreproc-Entities/FamixCPreprocInclude.class.st
@@ -54,6 +54,11 @@ FamixCPreprocInclude >> includedBy: anObject [
 	includedBy := anObject
 ]
 
+{ #category : #testing }
+FamixCPreprocInclude >> isInvocation [
+	^false
+]
+
 { #category : #accessing }
 FamixCPreprocInclude >> isLocal [
 

--- a/src/Famix-CPreproc-Generator/FamixCPreprocGenerator.class.st
+++ b/src/Famix-CPreproc-Generator/FamixCPreprocGenerator.class.st
@@ -62,7 +62,7 @@ FamixCPreprocGenerator >> defineHierarchy [
 	super defineHierarchy.
     
 	diskEntity --|> #TNamedEntity. 	
-   cFile --|> #TEntityMetaLevelDependency.
+   diskEntity --|> #TEntityMetaLevelDependency.
 	cFile --|> diskEntity. 
 	folder --|> diskEntity .
 


### PR DESCRIPTION
Problem: 
I got the following errors in the Architectural Map when generating it for FamixCPreproc entities:
- Instance of FamixCPreprocFolder did not understand #queryAllLocal
- Instance of FamixCPreprocInclude did not understand #isInvocation

Solution:
- Add the TEntityMetaLevelDependency trait to FamixCPreprocDiskEntity
- Remove the TEntityMetaLevelDependency trait FamixCPreprocCFile
- Implement the method isInvocation in FamixCPreprocInclude, returning false
