### PR TITLE
Add #isInvocation

### DIFF
--- a/src/Famix-CPreproc-Entities/FamixCPreprocInclude.class.st
+++ b/src/Famix-CPreproc-Entities/FamixCPreprocInclude.class.st
@@ -54,6 +54,11 @@ FamixCPreprocInclude >> includedBy: anObject [
 	includedBy := anObject
 ]
 
+{ #category : #testing }
+FamixCPreprocInclude >> isInvocation [
+	^false
+]
+
 { #category : #accessing }
 FamixCPreprocInclude >> isLocal [
 


### PR DESCRIPTION
Problem:
I got the following errors in the Architectural Map when generating it for FamixCPreproc entities:
- Instance of FamixCPreprocFolder did not understand #queryAllLocal
- Instance of FamixCPreprocInclude did not understand #isInvocation

Solution:
- Implement the method isInvocation in FamixCPreprocInclude, returning false
- https://github.com/moosetechnology/Famix-Cpp/pull/17