### PR TITLE
create included file based on root and not includer

### DIFF
--- a/src/Famix-CPreproc-Importer-Tests/FamixCPreprocVisitorTest.class.st
+++ b/src/Famix-CPreproc-Importer-Tests/FamixCPreprocVisitorTest.class.st
@@ -110,7 +110,7 @@ FamixCPreprocVisitorTest >> testCreateIncludeNewFile [
 { #category : #test }
 FamixCPreprocVisitorTest >> testCreateInclusionLocalToCurrentFile [
 	| includingFile includedFile dir |
-
+   1halt.
 	dir := self newEntity: FamixCPreprocFolder named: '.'.
 	dir := (self newEntity: FamixCPreprocFolder named: 'dir') parentFolder: dir ; yourself.
 	includingFile := (self newEntity: FamixCPreprocHeaderFile named: 'test.file') parentFolder: dir ; yourself.
@@ -123,7 +123,7 @@ FamixCPreprocVisitorTest >> testCreateInclusionLocalToCurrentFile [
 
 	includedFile := model entityNamed: 'included.file'.
 
-	self assert: includedFile parentFolder name equals: 'dir'.
+	self assert: includedFile parentFolder name equals: '.'.
 ]
 
 { #category : #test }

--- a/src/Famix-CPreproc-Importer-Tests/FamixCPreprocVisitorTest.class.st
+++ b/src/Famix-CPreproc-Importer-Tests/FamixCPreprocVisitorTest.class.st
@@ -113,7 +113,7 @@ FamixCPreprocVisitorTest >> testCreateInclusionLocalToCurrentFile [
 	dir := self newEntity: FamixCPreprocFolder named: '.'.
 	dir := (self newEntity: FamixCPreprocFolder named: 'dir') parentFolder: dir ; yourself.
 	includingFile := (self newEntity: FamixCPreprocHeaderFile named: 'test.file') parentFolder: dir ; yourself.
-
+   
 	visitor file: includingFile.
 
 	self assert: includingFile parentFolder name equals: 'dir'.

--- a/src/Famix-CPreproc-Importer-Tests/FamixCPreprocVisitorTest.class.st
+++ b/src/Famix-CPreproc-Importer-Tests/FamixCPreprocVisitorTest.class.st
@@ -72,7 +72,7 @@ FamixCPreprocVisitorTest >> testCreateIncludeExistingFile [
 	self assert: includedFile includes isEmpty.
 	self assert: includedFile inclusion isEmpty.
 	
-	visitor createInclude: './included.file' localTo: dir .
+	visitor createInclude: './included.file'.
 
 	self assert: includingFile includes size equals: 1.
 	self assert: includingFile inclusion isEmpty.
@@ -93,7 +93,7 @@ FamixCPreprocVisitorTest >> testCreateIncludeNewFile [
 	self assert: includingFile includes isEmpty.
 	self assert: includingFile inclusion isEmpty.
 	
-	visitor createInclude: './included.file' localTo: (self newEntity: FamixCPreprocFolder named: '.') .
+	visitor createInclude: './included.file'.
 
 	includedFile := model entityNamed: 'included.file'.
 
@@ -119,7 +119,7 @@ FamixCPreprocVisitorTest >> testCreateInclusionLocalToCurrentFile [
 
 	self assert: includingFile parentFolder name equals: 'dir'.
 	
-	visitor createInclude: './included.file' localTo: includingFile parentFolder.
+	visitor createInclude: './included.file'.
 
 	includedFile := model entityNamed: 'included.file'.
 

--- a/src/Famix-CPreproc-Importer-Tests/FamixCPreprocVisitorTest.class.st
+++ b/src/Famix-CPreproc-Importer-Tests/FamixCPreprocVisitorTest.class.st
@@ -72,7 +72,7 @@ FamixCPreprocVisitorTest >> testCreateIncludeExistingFile [
 	self assert: includedFile includes isEmpty.
 	self assert: includedFile inclusion isEmpty.
 	
-	visitor createInclude: './included.file'.
+	visitor createInclude: './included.file' localTo: dir .
 
 	self assert: includingFile includes size equals: 1.
 	self assert: includingFile inclusion isEmpty.
@@ -93,7 +93,7 @@ FamixCPreprocVisitorTest >> testCreateIncludeNewFile [
 	self assert: includingFile includes isEmpty.
 	self assert: includingFile inclusion isEmpty.
 	
-	visitor createInclude: './included.file'.
+	visitor createInclude: './included.file' localTo: (self newEntity: FamixCPreprocFolder named: '.') .
 
 	includedFile := model entityNamed: 'included.file'.
 
@@ -109,8 +109,7 @@ FamixCPreprocVisitorTest >> testCreateIncludeNewFile [
 
 { #category : #test }
 FamixCPreprocVisitorTest >> testCreateInclusionLocalToCurrentFile [
-	| includingFile includedFile dir |
-   1halt.
+	| includingFile includedFile includedFileLocal dir |
 	dir := self newEntity: FamixCPreprocFolder named: '.'.
 	dir := (self newEntity: FamixCPreprocFolder named: 'dir') parentFolder: dir ; yourself.
 	includingFile := (self newEntity: FamixCPreprocHeaderFile named: 'test.file') parentFolder: dir ; yourself.
@@ -119,7 +118,15 @@ FamixCPreprocVisitorTest >> testCreateInclusionLocalToCurrentFile [
 
 	self assert: includingFile parentFolder name equals: 'dir'.
 	
-	visitor createInclude: './included.file'.
+	"include with relative path"
+	visitor createInclude: 'local.file' localTo: includingFile parentFolder.
+
+	includedFileLocal := model entityNamed: 'local.file'.
+
+	self assert: includedFileLocal parentFolder name equals: 'dir'.
+	
+	"include with absolute path"
+	visitor createInclude: './included.file' localTo: includingFile parentFolder.
 
 	includedFile := model entityNamed: 'included.file'.
 

--- a/src/Famix-CPreproc-Importer/FamixCPreprocVisitor.class.st
+++ b/src/Famix-CPreproc-Importer/FamixCPreprocVisitor.class.st
@@ -18,22 +18,12 @@ FamixCPreprocVisitor >> createFile: aName [
 ]
 
 { #category : #'private-entity-creation' }
-FamixCPreprocVisitor >> createInclude: aName [ 
-	| included |
-	included := self createFile: aName.
-	FamixCPreprocInclude new
-		mooseModel: self model ;
-		included: included ;
-		includedBy: file.
-]
-
-{ #category : #'private-entity-creation' }
 FamixCPreprocVisitor >> createInclude: aName localTo: folder [
 	| included |
 	"if the include name itself is an absolute path, do not create file under relative path"
-	included := aName first == '.'
-		            ifTrue: [ self createFile: folder fullName , '/' , aName ]
-		            ifFalse: [ self createFile: aName ].
+	included := aName first == $.
+		            ifTrue: [ self createFile: aName ]
+		            ifFalse: [ self createFile: folder fullName , '/' , aName ].
 	FamixCPreprocInclude new
 		mooseModel: self model;
 		included: included;

--- a/src/Famix-CPreproc-Importer/FamixCPreprocVisitor.class.st
+++ b/src/Famix-CPreproc-Importer/FamixCPreprocVisitor.class.st
@@ -28,6 +28,19 @@ FamixCPreprocVisitor >> createInclude: aName [
 ]
 
 { #category : #'private-entity-creation' }
+FamixCPreprocVisitor >> createInclude: aName localTo: folder [
+	| included |
+	"if the include name itself is an absolute path, do not create file under relative path"
+	included := aName first == '.'
+		            ifTrue: [ self createFile: folder fullName , '/' , aName ]
+		            ifFalse: [ self createFile: aName ].
+	FamixCPreprocInclude new
+		mooseModel: self model;
+		included: included;
+		includedBy: file
+]
+
+{ #category : #'private-entity-creation' }
 FamixCPreprocVisitor >> detectCFile: aName in: folder ofClass: concreteClass [
    ^folder children
 		detect: [ :f | f name = aName ]
@@ -118,7 +131,7 @@ FamixCPreprocVisitor >> visitInclude: aNode [
 
 { #category : #visiting }
 FamixCPreprocVisitor >> visitIncludeLocal: aNode [
-	self createInclude: (aNode attributeAt: 'name').
+	self createInclude: (aNode attributeAt: 'name') localTo: file parentFolder.
 
 ]
 

--- a/src/Famix-CPreproc-Importer/FamixCPreprocVisitor.class.st
+++ b/src/Famix-CPreproc-Importer/FamixCPreprocVisitor.class.st
@@ -18,9 +18,9 @@ FamixCPreprocVisitor >> createFile: aName [
 ]
 
 { #category : #'private-entity-creation' }
-FamixCPreprocVisitor >> createInclude: aName localTo: folder [
+FamixCPreprocVisitor >> createInclude: aName [ 
 	| included |
-	included := self createFile: (folder fullName , '/' , aName).
+	included := self createFile: aName.
 	FamixCPreprocInclude new
 		mooseModel: self model ;
 		included: included ;
@@ -118,7 +118,7 @@ FamixCPreprocVisitor >> visitInclude: aNode [
 
 { #category : #visiting }
 FamixCPreprocVisitor >> visitIncludeLocal: aNode [
-	self createInclude: (aNode attributeAt: 'name') localTo: file parentFolder.
+	self createInclude: (aNode attributeAt: 'name').
 
 ]
 


### PR DESCRIPTION
**Issue**
Let's suppose I have an XML file like this:

`<file name="./foo/bar/LibraryInfo.h"></file>
<file name="./foo/bar/Precompiled.h"></file>
<file name="./foo/bar/LibraryInfo.cpp">
<include type="local" name="./foo/bar/LibraryInfo.h" />
<include type="local" name="./foo/bar/Precompiled.h" />
</file>`

Result: all files are created correctly in the model, according to the file/folder hierarchy. However, there might be a case where a file is only mentioned in the XML as include, and not as file. For example:

`<file name="./foo/bar/LibraryInfo.cpp">
<include type="local" name="./foo/bar/LibraryInfo.h" />
<include type="local" name="./foo/bar/Precompiled.h" />
</file>`

In this case, LibraryInfo.cpp will be created under the correct folder hierarchy (./foo/bar), but LibraryInfo.h and Precompiled.h will be created under a duplicated and therefore incorrect folder hierarchy: ./foo/bar/foo/bar/LibraryInfo.h.

Why does it happen? This happens because the importer was written assuming that all include paths are relative to the files which are including them. This is not always true for the game engines I'm analysing, and for this reason, I resolve all include paths to absolute paths before running the importer. 

**Solution**
Given that all my paths are absolute, there is no reason to deal with them as relative in any methods in the FamixCPreprocVisitor. Therefore, I changed the methods to work both with absolute and relative paths. In my game engine parser, all absolute paths are identified by a trailing dot. If the path starts with a dot, the importer will then consider it to be absolute. Otherwise, the importer will consider it to be relative.

